### PR TITLE
An improvement for iOS and a bugfix for Android

### DIFF
--- a/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Module.java
+++ b/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Module.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.io.ByteArrayOutputStream;
 
 import android.content.Context;
+import android.content.res.AssetFileDescriptor;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.util.Base64;
@@ -35,7 +36,13 @@ public class ImageToBase64Module extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getBase64String(String uri, Callback callback) {
     try {
-      Bitmap image = MediaStore.Images.Media.getBitmap(this.context.getContentResolver(), Uri.parse(uri));
+      BitmapFactory.Options options = new BitmapFactory.Options();
+      options.inSampleSize = 5;
+
+      AssetFileDescriptor fileDescriptor =null;
+      fileDescriptor = this.context.getContentResolver().openAssetFileDescriptor(Uri.parse(uri), "r");
+
+      Bitmap image = BitmapFactory.decodeFileDescriptor(fileDescriptor.getFileDescriptor(), null, options);
       if (image == null) {
         callback.invoke("Failed to decode Bitmap, uri: " + uri);
       } else {

--- a/ios/RNImageToBase64.m
+++ b/ios/RNImageToBase64.m
@@ -11,15 +11,35 @@ RCT_EXPORT_METHOD(getBase64String:(NSString *)input callback:(RCTResponseSenderB
   NSURL *url = [[NSURL alloc] initWithString:input];
   ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
   [library assetForURL:url resultBlock:^(ALAsset *asset) {
-    ALAssetRepresentation *rep = [asset defaultRepresentation];
-    CGImageRef imageRef = [rep fullScreenImage];
+    
+      
+    CGImageRef imageRef = [self rotatePortraitImageFromAsset:asset];
     NSData *imageData = UIImagePNGRepresentation([UIImage imageWithCGImage:imageRef]);
     NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
     callback(@[[NSNull null], base64Encoded]);
+      
   } failureBlock:^(NSError *error) {
     NSLog(@"that didn't work %@", error);
     callback(@[error]);
   }];
 }
+
+-(CGImageRef) rotatePortraitImageFromAsset:(ALAsset*) asset {
+    ALAssetRepresentation *rep = [asset defaultRepresentation];
+    
+    if ([rep orientation] == ALAssetOrientationUp){
+        return [rep fullScreenImage];
+    } else {
+        CGImageRef ref = [rep fullScreenImage];
+        UIImage* testImage = [UIImage imageWithCGImage:ref];
+        
+        UIGraphicsBeginImageContextWithOptions(testImage.size, NO, testImage.scale);
+        [testImage drawInRect:(CGRect){0, 0, testImage.size}];
+        UIImage *normalizedImage = UIGraphicsGetImageFromCurrentImageContext();
+        UIGraphicsEndImageContext();
+        return [testImage CGImage];
+    }
+}
+
 
 @end


### PR DESCRIPTION
When image on iDevice is taken in portrait mode module currently returns it rotated, this PR fixes this behavior.
On Android, when image is large it crashes application with out of memory exception, using a new way to retrieve bitmap from uri fixes the crash.