### PR TITLE
Add handling local url without ALAssetsLibrary

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
   buildToolsVersion "24.0.2"
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 16
     targetSdkVersion 23
     versionCode 1
     versionName "1.0"

--- a/ios/RNImageToBase64.m
+++ b/ios/RNImageToBase64.m
@@ -8,18 +8,25 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(getBase64String:(NSString *)input callback:(RCTResponseSenderBlock)callback)
 {
-  NSURL *url = [[NSURL alloc] initWithString:input];
-  ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
-  [library assetForURL:url resultBlock:^(ALAsset *asset) {
-    ALAssetRepresentation *rep = [asset defaultRepresentation];
-    CGImageRef imageRef = [rep fullScreenImage];
-    NSData *imageData = UIImagePNGRepresentation([UIImage imageWithCGImage:imageRef]);
-    NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
-    callback(@[[NSNull null], base64Encoded]);
-  } failureBlock:^(NSError *error) {
-    NSLog(@"that didn't work %@", error);
-    callback(@[error]);
-  }];
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
+    dispatch_async(dispatch_get_main_queue(), ^{
+      UIImage *image = [UIImage imageWithContentsOfFile:input];
+      NSString *base64 = [UIImagePNGRepresentation(image) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+      callback(@[[NSNull null], base64]);
+    });
+  });
+//   NSURL *url = [[NSURL alloc] initWithString:input];
+//   ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];
+//   [library assetForURL:url resultBlock:^(ALAsset *asset) {
+//     ALAssetRepresentation *rep = [asset defaultRepresentation];
+//     CGImageRef imageRef = [rep fullScreenImage];
+//     NSData *imageData = UIImagePNGRepresentation([UIImage imageWithCGImage:imageRef]);
+//     NSString *base64Encoded = [imageData base64EncodedStringWithOptions:0];
+//     callback(@[[NSNull null], base64Encoded]);
+//   } failureBlock:^(NSError *error) {
+//     NSLog(@"that didn't work %@", error);
+//     callback(@[error]);
+//   }];
 }
 
 @end

--- a/ios/RNImageToBase64.m
+++ b/ios/RNImageToBase64.m
@@ -9,11 +9,9 @@ RCT_EXPORT_MODULE();
 RCT_EXPORT_METHOD(getBase64String:(NSString *)input callback:(RCTResponseSenderBlock)callback)
 {
   dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0), ^{
-    dispatch_async(dispatch_get_main_queue(), ^{
-      UIImage *image = [UIImage imageWithContentsOfFile:input];
-      NSString *base64 = [UIImagePNGRepresentation(image) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
-      callback(@[[NSNull null], base64]);
-    });
+    UIImage *image = [UIImage imageWithContentsOfFile:input];
+    NSString *base64 = [UIImagePNGRepresentation(image) base64EncodedStringWithOptions:NSDataBase64Encoding64CharacterLineLength];
+    callback(@[[NSNull null], base64]);
   });
 //   NSURL *url = [[NSURL alloc] initWithString:input];
 //   ALAssetsLibrary *library = [[ALAssetsLibrary alloc] init];


### PR DESCRIPTION
ALAssetsLibrary is deprecated as of iOS 9.0.
I will try to replace ALAssetsLibrary with Photos framework.