### PR TITLE
Removed the annotation to support RN v0.47.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,3 @@ NativeModules.RNImageToBase64.getBase64String(uri, (err, base64) => {
   // Do something with the base64 string
 })
 ```
-
-<a target='_blank' rel='nofollow' href='https://app.codesponsor.io/link/cu1HheDZfnqZS4YAy7Hf8bGU/xfumihiro/react-native-image-to-base64'>
-  <img alt='Sponsor' width='888' height='68' src='https://app.codesponsor.io/embed/cu1HheDZfnqZS4YAy7Hf8bGU/xfumihiro/react-native-image-to-base64.svg' />
-</a>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
   buildToolsVersion "24.0.2"
 
   defaultConfig {
-    minSdkVersion 15
+    minSdkVersion 16
     targetSdkVersion 23
     versionCode 1
     versionName "1.0"

--- a/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Package.java
+++ b/android/src/main/java/com/github/xfumihiro/react_native_image_to_base64/ImageToBase64Package.java
@@ -22,7 +22,6 @@ public class ImageToBase64Package implements ReactPackage {
     return modules;
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
The function is removed in the ReactPackage, so the @override annotation breaks.

Allows this module to work in earlier versions as well.